### PR TITLE
Do not return error if session to be deleted does not exist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,9 +119,17 @@ impl SessionStore for FileSessionStorage {
     }
 
     async fn delete(&self, session_id: &Id) -> session_store::Result<()> {
-        remove_file(self.folder_name.join(session_id.to_string()))
-            .await
-            .map_err(|_| session_store::Error::Backend("Failed to Delete".to_string()))?;
+        let res = remove_file(self.folder_name.join(session_id.to_string())).await;
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    return Err(session_store::Error::Backend(
+                        "Failed to Delete".to_string(),
+                    ));
+                }
+            }
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
For example if server restarted (and .session is emptied), but the user still has old session cookie: the deletion will fail, and the user is unable to continue unless cookie is cleared. This patch solves this issue.